### PR TITLE
SSIG-27 : [SIG-12][BD] Change data type for 'Case Id' to Long to allow for larger investigation IDs

### DIFF
--- a/link/cartridges/int_signifyd/cartridge/scripts/service/signifyd.js
+++ b/link/cartridges/int_signifyd/cartridge/scripts/service/signifyd.js
@@ -533,7 +533,7 @@ exports.Call = function (order) {
                         var caseId = answer.investigationId;
                         Transaction.wrap(function () {
                             // eslint-disable-next-line no-param-reassign
-                            order.custom.SignifydCaseID = caseId;
+                            order.custom.SignifydCaseID = String(caseId);
                         });
                         return caseId;
                     }


### PR DESCRIPTION
`signifyd.js`: included String constructor method to make sure that the caseId variable is stored as a String, not as a Number