### PR TITLE
SSIG-33 : [SIG-16][BD] Implement passive mode for Pre and post auth implementations

### DIFF
--- a/link/cartridges/int_signifyd_sfra/cartridge/controllers/CheckoutServices.js
+++ b/link/cartridges/int_signifyd_sfra/cartridge/controllers/CheckoutServices.js
@@ -120,6 +120,7 @@ server.replace('PlaceOrder', server.middleware.https, function (req, res, next) 
     }
 
     if (SignifydCreateCasePolicy == "PRE_AUTH") {
+        var SignifydPreAuthBurnInMode = dw.system.Site.getCurrent().getCustomPreferenceValue('SignifydPreAuthBurnInMode');
         Signifyd.setOrderSessionId(order, orderSessionID);
         var response = Signifyd.Call(order);
 
@@ -128,13 +129,17 @@ server.replace('PlaceOrder', server.middleware.https, function (req, res, next) 
                 if (response.declined) {
                     order.custom.SignifydOrderFailedReason = Resource.msg('error.signifyd.order.failed.reason', 'signifyd', null);
                 }
-                OrderMgr.failOrder(order);
+                if (!SignifydPreAuthBurnInMode) {
+                    OrderMgr.failOrder(order);
+                }
             });
-            res.json({
-                error: true,
-                errorMessage: Resource.msg('error.technical', 'checkout', null)
-            });
-           return next();
+            if (!SignifydPreAuthBurnInMode) {
+                res.json({
+                    error: true,
+                    errorMessage: Resource.msg('error.technical', 'checkout', null)
+                });
+                return next();
+            }
         }
     }
 

--- a/link/metadata/meta/system-objecttype-extensions.xml
+++ b/link/metadata/meta/system-objecttype-extensions.xml
@@ -125,6 +125,14 @@
                 <externally-managed-flag>false</externally-managed-flag>
                 <default-value>3</default-value>
             </attribute-definition>
+            <attribute-definition attribute-id="SignifydPreAuthBurnInMode">
+                <display-name xml:lang="x-default">Signifyd Pre-Auth Burn In Mode</display-name>
+                <description xml:lang="x-default">Signifyd Pre-Auth Burn In Mode</description>
+                <type>boolean</type>
+                <mandatory-flag>false</mandatory-flag>
+                <externally-managed-flag>false</externally-managed-flag>
+                <default-value>true</default-value>
+            </attribute-definition>
             <attribute-definition attribute-id="SignifydEnableDecisionCentre">
                 <display-name xml:lang="x-default">Enable Decision Centre</display-name>
                 <description xml:lang="x-default">Enable only if you are using Signifyd's Decision Centre product and DECISION_MADE webhook.</description>
@@ -175,6 +183,7 @@
                 <attribute attribute-id="SignifydEnableCartridge"/>
                 <attribute attribute-id="SignifydMaxRetryCount"/>
                 <attribute attribute-id="SignifydEnableDecisionCentre"/>
+                <attribute attribute-id="SignifydPreAuthBurnInMode"/>
             </attribute-group>
         </group-definitions>
     </type-extension>


### PR DESCRIPTION
**Info:** With this ticket, we added a new custom preference for Signifyd **called SignifydPreAuthBurnInMode** when this burn-in mode is on, even if we use the information to make the order fail, the order is not going to fail.

- **CheckoutServices.js:** Added a condition for the order to fail and the error to appear on the storefront.

![image](https://user-images.githubusercontent.com/72388873/129046804-61a2659e-5ca8-4dd3-9d10-9a9faaa5a447.png)
