### PR TITLE
SSIG-39 : [SIG-18][BD] Pre-Auth Accept/Decline Logic Change (V2)

### DIFF
--- a/link/cartridges/int_signifyd/cartridge/scripts/service/signifyd.js
+++ b/link/cartridges/int_signifyd/cartridge/scripts/service/signifyd.js
@@ -684,17 +684,17 @@ exports.Call = function (order) {
                         if (SignifydCreateCasePolicy === "PRE_AUTH") {
                             caseId = answer.caseId;
                             if (answer.checkpointAction) {
-                                if (answer.checkpointAction !== "ACCEPT") {
+                                if (answer.checkpointAction === "REJECT") {
                                     declined = true;
                                 }
                             } else {
                                 if (answer.recommendedAction) {
-                                    if (answer.recommendedAction !== "ACCEPT") {
+                                    if (answer.recommendedAction === "REJECT") {
                                         declined = true;
                                     }
                                 } else {
                                     if (answer.decisions.paymentFraud.status) {
-                                        if (answer.decisions.paymentFraud.status !== "APPROVED") {
+                                        if (answer.decisions.paymentFraud.status === "DECLINED") {
                                             declined = true;
                                         }
                                     }
@@ -710,7 +710,7 @@ exports.Call = function (order) {
                                 var orderUrl = 'https://www.signifyd.com/cases/' + caseId;
                                 order.custom.SignifydOrderURL = orderUrl;
 
-                                if (answer.checkpointAction) {
+                                if (typeof answer.checkpointAction !== 'undefined' ) {
                                     order.custom.SignifydFraudScore = answer.score;
                                     order.custom.SignifydPolicy = answer.checkpointAction;
                                     order.custom.SignifydPolicyName = answer.checkpointActionReason || '';


### PR DESCRIPTION
**Info:** The ticket enables the order to not be declined in conditons of hold, pending, null etc. The order is declined only in the case of REJECT.

- when we have the **answer.checkpointAction**, we are going to check if its value is **REJECT** and only then decline it, for other values it is not going to be declined.

- when we don't have **answer.checkpointAction** we check the **answer.recommendedAction** and check if its value is **REJECT** and only then decline it, for other values it is not going to be declined.

- if **answer.recommendedAction** doesn't exist we are checking **answer.decisions.paymentFraud.status** if it is **DECLINED** then we are going to decline it otherwise we are not.