### PR TITLE
[SFCC-31]: Do not send Failed Order (failed auth) to Signifyd

### DIFF
--- a/link/cartridges/int_signifyd/cartridge/scripts/service/signifyd.js
+++ b/link/cartridges/int_signifyd/cartridge/scripts/service/signifyd.js
@@ -695,7 +695,7 @@ exports.Call = function (order) {
     var returnObj = {};
     var declined = false;
 
-    if (EnableCartridge && checkPaymentMethodExclusion(order)) {
+    if (EnableCartridge && checkPaymentMethodExclusion(order) && order.getStatus() != order.ORDER_STATUS_FAILED) {
         if (order && order.currentOrderNo) {
             var SignifydCreateCasePolicy = dw.system.Site.getCurrent().getCustomPreferenceValue('SignifydCreateCasePolicy').value;
             var service;

--- a/link/cartridges/int_signifyd_sfra/cartridge/controllers/CheckoutServices.js
+++ b/link/cartridges/int_signifyd_sfra/cartridge/controllers/CheckoutServices.js
@@ -193,9 +193,7 @@ server.replace('PlaceOrder', server.middleware.https, function (req, res, next) 
         Signifyd.SendTransaction(order);
     } else {
         Signifyd.setOrderSessionId(order, orderSessionID);
-        if (order && order.getStatus() != order.ORDER_STATUS_FAILED) {
-            Signifyd.Call(order);
-        }
+        Signifyd.Call(order);
     }
     /* Signifyd Modification End */
 


### PR DESCRIPTION
PR changes:

- link/cartridges/int_signifyd_sfra/cartridge/controllers/CheckoutServices.js: Checking if the order is failed before sending it to Signifyd